### PR TITLE
System tray icon is toggleable, and GitHub Enterprise hostname can be set in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ The app is not very pretty right now, it's just functional. I'm open to suggesti
 
 ## System Requirements
 
-* JDK 1.8.0_31 (to build from source, until I do an actual release)
+* JDK 1.8.0_31+ (to build from source, until I do an actual release)
 * Linux, Mac, or Windows
+  * If Linux and using Gnome or Cinnamon, the tray icon does not work. Please disable it in the preferences.
 
 ## Running it quickly from Gradle
 
@@ -22,9 +23,8 @@ If you just want to fire it up to play around with it, use the `run` task.
 
 1. Clone/update the repo.
 2. `./gradlew clean run`
-  * By default, the user and token are not set. Click on Edit -> Preferences to do so. Note that the preferences will not be stored.
+  * By default, the user and token are not set. Click on Edit -> Preferences to do so. Note that the preferences will not be stored until issue #6 is resolved.
   * Warning: if you do not set [an OAuth token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/), then GitHub will start [rejecting requests above 60 per hour](https://developer.github.com/v3/#rate-limiting).
-  * Also until issue #5 is fixed, you can't set the GitHub Enterprise hostname from the UI, only from the command line parameter. See below for an example.
 
 ## Building the self-contained app
 
@@ -55,9 +55,7 @@ The app is setup to talk to GitHub.com, as long as the username is entered.
 
 ## How to use with GitHub Enterprise
 
-Note: Until issue #5 is fixed, you can't set the GitHub Enterprise hostname from the UI, only from the command line parameter.
-
 1. Get [an OAuth token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/) for your GitHub Enterprise account. It does not require any special permissions/scopes, so it is recommended that you uncheck all of the scopes.
-2. Start the app with `-u <user> -t <token> -n <github_enterprise_hostname>`.
+2. Open `GitHub Desktop Notifier`, click on `Edit -> Preferences`, and put in the user name and OAuth token and GitHub Enterprise hostname, then click OK.
   * Or, `./gradlew run -Parguments=-u,jhegg,-t,12345,-n,localhost`
 3. If you get an `SSLPeerUnverifiedException`, then the most likely cause is that the SSL certificate presented by the GitHub Enterprise server is not trusted by the JRE's `cacerts` keystore. The keystore of the JRE needs to have the certificate imported. If you are using `./gradlew run`, then the keystore is `$JAVA_HOME/jre/lib/security/cacerts`; but if you use the `jfxDeploy` task, it will be the `build/distributions/github-desktop-notifier/runtime/jre/lib/security/cacerts` file. If you don't know what to do, look up the documentation for Java's `keytool` regarding importing certificates into a keystore.

--- a/src/main/groovy/com/jhegg/github/notifier/App.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/App.groovy
@@ -59,6 +59,7 @@ class App extends Application {
         configurePrimaryStage()
         primaryStage.show()
         if (useTrayIcon) {
+            Platform.setImplicitExit(false)
             Platform.runLater { addAppToTray() }
         }
     }

--- a/src/main/groovy/com/jhegg/github/notifier/CenterLayoutController.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/CenterLayoutController.groovy
@@ -30,6 +30,8 @@ class CenterLayoutController {
 
     DesktopNotifier desktopNotifier = new DesktopNotifier()
 
+    def pleaseSetUserNameMessage = "Please click on Edit->Preferences and set a GitHub User Name."
+
     @SuppressWarnings("GroovyUnusedDeclaration")
     @FXML
     void initialize() {
@@ -56,7 +58,7 @@ class CenterLayoutController {
         if (app.userName) {
             gitHubService.start()
         } else {
-            textArea.setText("Please click on Edit->Preferences and set a GitHub User Name.")
+            textArea.setText(pleaseSetUserNameMessage)
         }
     }
 
@@ -124,6 +126,8 @@ class CenterLayoutController {
         if (app.userName) {
             textArea.setText("Loading...")
             gitHubService.restart() // todo This is not an ideal usage for proper error handling
+        } else {
+            textArea.setText(pleaseSetUserNameMessage)
         }
     }
 

--- a/src/main/groovy/com/jhegg/github/notifier/EditPreferencesController.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/EditPreferencesController.groovy
@@ -3,6 +3,7 @@ package com.jhegg.github.notifier
 import javafx.event.EventHandler
 import javafx.fxml.FXML
 import javafx.scene.Scene
+import javafx.scene.control.CheckBox
 import javafx.scene.control.TextField
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
@@ -13,11 +14,20 @@ import javafx.stage.Stage
 class EditPreferencesController {
     @FXML
     TextField token
+
     @FXML
     TextField userName
 
+    @FXML
+    TextField gitHubEnterpriseHostname
+
+    @FXML
+    CheckBox systemTrayIcon
+
     App app
+
     Stage dialogStage
+
     boolean wasOkClicked
 
     @SuppressWarnings("GroovyUnusedDeclaration")
@@ -27,7 +37,7 @@ class EditPreferencesController {
     }
 
     private Iterable<TextField> pressingEnterKeyClicksOk() {
-        [token, userName].each {
+        [token, userName, gitHubEnterpriseHostname, systemTrayIcon].each {
             it.setOnKeyPressed(new EventHandler<KeyEvent>() {
                 @Override
                 void handle(KeyEvent event) {
@@ -44,6 +54,7 @@ class EditPreferencesController {
     void clickedOk() {
         app.userName = userName.getText()
         app.token = token.getText()
+        app.gitHubEnterpriseHostname = gitHubEnterpriseHostname.getText()
         wasOkClicked = true
         closeDialog()
     }

--- a/src/main/groovy/com/jhegg/github/notifier/EditPreferencesController.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/EditPreferencesController.groovy
@@ -70,6 +70,7 @@ class EditPreferencesController {
         dialogStage.setTitle("Edit Preferences")
         dialogStage.initModality(Modality.WINDOW_MODAL)
         dialogStage.initOwner(app.primaryStage)
+        dialogStage.setResizable(false)
         dialogStage.setScene(new Scene(pane))
     }
 

--- a/src/main/groovy/com/jhegg/github/notifier/EditPreferencesController.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/EditPreferencesController.groovy
@@ -55,6 +55,9 @@ class EditPreferencesController {
         app.userName = userName.getText()
         app.token = token.getText()
         app.gitHubEnterpriseHostname = gitHubEnterpriseHostname.getText()
+        if (systemTrayIcon.selected != app.useTrayIcon) {
+            app.toggleTrayIcon()
+        }
         wasOkClicked = true
         closeDialog()
     }
@@ -65,15 +68,17 @@ class EditPreferencesController {
         closeDialog()
     }
 
-    void setDisplayedPreferences(String token, String userName) {
+    void setDisplayedPreferences(String token, String userName, String hostname, boolean useTrayIcon) {
         this.token.setText(token)
         this.userName.setText(userName)
+        this.gitHubEnterpriseHostname.setText(hostname)
+        this.systemTrayIcon.selected = useTrayIcon
     }
 
     void configure(App app, Pane pane) {
         this.app = app
         buildDialogStage(pane)
-        setDisplayedPreferences(app.token, app.userName)
+        setDisplayedPreferences(app.token, app.userName, app.gitHubEnterpriseHostname, app.useTrayIcon)
     }
 
     private void buildDialogStage(Pane pane) {
@@ -86,7 +91,7 @@ class EditPreferencesController {
     }
 
     void showDialog() {
-        setDisplayedPreferences(app.token, app.userName)
+        setDisplayedPreferences(app.token, app.userName, app.gitHubEnterpriseHostname, app.useTrayIcon)
         dialogStage.showAndWait()
     }
 

--- a/src/main/resources/EditPreferences.fxml
+++ b/src/main/resources/EditPreferences.fxml
@@ -4,25 +4,14 @@
 <?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.jhegg.github.notifier.EditPreferencesController">
+<AnchorPane maxHeight="400.0" maxWidth="600.0" minHeight="252.0" minWidth="401.0" prefHeight="252.0" prefWidth="401.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.jhegg.github.notifier.EditPreferencesController">
     <children>
-        <GridPane layoutX="14.0" layoutY="14.0" prefHeight="291.0" prefWidth="578.0" AnchorPane.leftAnchor="5.0" AnchorPane.rightAnchor="5.0" AnchorPane.topAnchor="5.0">
-            <columnConstraints>
-                <ColumnConstraints hgrow="SOMETIMES" maxWidth="290.0" minWidth="10.0" prefWidth="128.0" />
-                <ColumnConstraints hgrow="SOMETIMES" maxWidth="493.0" minWidth="10.0" prefWidth="462.0" />
-            </columnConstraints>
-            <rowConstraints>
-                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-            </rowConstraints>
-            <children>
-                <Label text="GitHub OAuth Token" />
-                <Label text="GitHub user to monitor" GridPane.rowIndex="1" />
-                <TextField fx:id="token" GridPane.columnIndex="1" />
-                <TextField fx:id="userName" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-            </children>
-        </GridPane>
-        <Button onAction="#clickedOk" layoutX="431.0" layoutY="361.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="70.0" text="OK" />
-        <Button onAction="#clickedCancel" layoutX="516.0" layoutY="361.0" mnemonicParsing="false" prefHeight="25.0" prefWidth="70.0" text="Cancel" />
+        <Button layoutX="214.0" layoutY="211.0" mnemonicParsing="false" onAction="#clickedOk" prefHeight="25.0" prefWidth="70.0" text="OK" />
+        <Button layoutX="304.0" layoutY="211.0" mnemonicParsing="false" onAction="#clickedCancel" prefHeight="25.0" prefWidth="70.0" text="Cancel" />
+      <CheckBox layoutX="30.0" layoutY="152.0" mnemonicParsing="false" text="Use System Tray icon" />
+          <TextField fx:id="userName" layoutX="30.0" layoutY="103.0" prefHeight="25.0" prefWidth="344.0" />
+          <Label layoutX="30.0" layoutY="83.0" text="GitHub user to monitor (Required)" />
+          <Label layoutX="30.0" layoutY="23.0" text="GitHub OAuth Token (Optional)" />
+          <TextField fx:id="token" layoutX="30.0" layoutY="40.0" prefHeight="25.0" prefWidth="344.0" />
     </children>
 </AnchorPane>

--- a/src/main/resources/EditPreferences.fxml
+++ b/src/main/resources/EditPreferences.fxml
@@ -4,14 +4,36 @@
 <?import java.lang.*?>
 <?import javafx.scene.layout.*?>
 
-<AnchorPane maxHeight="400.0" maxWidth="600.0" minHeight="252.0" minWidth="401.0" prefHeight="252.0" prefWidth="401.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.jhegg.github.notifier.EditPreferencesController">
+<AnchorPane maxHeight="400.0" maxWidth="600.0" minHeight="252.0" minWidth="381.0" prefHeight="290.0" prefWidth="381.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.jhegg.github.notifier.EditPreferencesController">
     <children>
-        <Button layoutX="214.0" layoutY="211.0" mnemonicParsing="false" onAction="#clickedOk" prefHeight="25.0" prefWidth="70.0" text="OK" />
-        <Button layoutX="304.0" layoutY="211.0" mnemonicParsing="false" onAction="#clickedCancel" prefHeight="25.0" prefWidth="70.0" text="Cancel" />
-      <CheckBox layoutX="30.0" layoutY="152.0" mnemonicParsing="false" text="Use System Tray icon" />
-          <TextField fx:id="userName" layoutX="30.0" layoutY="103.0" prefHeight="25.0" prefWidth="344.0" />
-          <Label layoutX="30.0" layoutY="83.0" text="GitHub user to monitor (Required)" />
-          <Label layoutX="30.0" layoutY="23.0" text="GitHub OAuth Token (Optional)" />
-          <TextField fx:id="token" layoutX="30.0" layoutY="40.0" prefHeight="25.0" prefWidth="344.0" />
+      <VBox layoutX="20.0" layoutY="15.0" spacing="20.0">
+         <children>
+            <VBox layoutX="30.0" layoutY="17.0" spacing="5.0">
+               <children>
+                      <Label layoutX="30.0" layoutY="83.0" text="GitHub user to monitor (Required)" />
+                      <TextField fx:id="userName" layoutX="30.0" layoutY="103.0" prefHeight="25.0" prefWidth="344.0" />
+               </children>
+            </VBox>
+            <VBox layoutX="22.0" layoutY="74.0" spacing="5.0">
+               <children>
+                      <Label layoutX="30.0" layoutY="19.0" text="GitHub OAuth token (Optional)" />
+                      <TextField fx:id="token" layoutX="30.0" layoutY="40.0" prefHeight="25.0" prefWidth="344.0" />
+               </children>
+            </VBox>
+            <VBox layoutX="10.0" layoutY="77.0" spacing="5.0">
+               <children>
+                  <Label layoutX="30.0" layoutY="19.0" text="GitHub Enterprise hostname (Optional)" />
+                  <TextField fx:id="token1" layoutX="30.0" layoutY="40.0" prefHeight="25.0" prefWidth="344.0" />
+               </children>
+            </VBox>
+            <CheckBox layoutX="23.0" layoutY="134.0" mnemonicParsing="false" selected="true" text="Enable System Tray icon" />
+            <HBox alignment="TOP_RIGHT" prefHeight="16.0" prefWidth="344.0" spacing="10.0">
+               <children>
+                    <Button mnemonicParsing="false" onAction="#clickedOk" prefHeight="25.0" prefWidth="70.0" text="OK" />
+                    <Button mnemonicParsing="false" onAction="#clickedCancel" prefHeight="25.0" prefWidth="70.0" text="Cancel" />
+               </children>
+            </HBox>
+         </children>
+      </VBox>
     </children>
 </AnchorPane>

--- a/src/main/resources/EditPreferences.fxml
+++ b/src/main/resources/EditPreferences.fxml
@@ -23,10 +23,10 @@
             <VBox layoutX="10.0" layoutY="77.0" spacing="5.0">
                <children>
                   <Label layoutX="30.0" layoutY="19.0" text="GitHub Enterprise hostname (Optional)" />
-                  <TextField fx:id="token1" layoutX="30.0" layoutY="40.0" prefHeight="25.0" prefWidth="344.0" />
+                  <TextField fx:id="gitHubEnterpriseHostname" layoutX="30.0" layoutY="40.0" prefHeight="25.0" prefWidth="344.0" />
                </children>
             </VBox>
-            <CheckBox layoutX="23.0" layoutY="134.0" mnemonicParsing="false" selected="true" text="Enable System Tray icon" />
+            <CheckBox fx:id="systemTrayIcon" layoutX="23.0" layoutY="134.0" mnemonicParsing="false" selected="true" text="Enable System Tray icon" />
             <HBox alignment="TOP_RIGHT" prefHeight="16.0" prefWidth="344.0" spacing="10.0">
                <children>
                     <Button mnemonicParsing="false" onAction="#clickedOk" prefHeight="25.0" prefWidth="70.0" text="OK" />

--- a/src/test/groovy/com/jhegg/github/notifier/AppTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/AppTest.groovy
@@ -70,4 +70,27 @@ class AppTest extends Specification {
         1 * tray.add(_ as TrayIcon)
         1 * trayIcon.setImageAutoSize(true)
     }
+
+    @Unroll
+    def "toggleTrayIcon when useTrayIcon=#useTrayIcon"() {
+        given:
+        app.useTrayIcon = useTrayIcon
+        boolean removed = false
+        boolean added = false
+        app.metaClass.removeAppFromTray = { removed = true }
+        app.metaClass.addAppToTray = { added = true }
+
+        when:
+        app.toggleTrayIcon()
+
+        then:
+        app.useTrayIcon != useTrayIcon
+        removed == wasRemoveCalled
+        added == wasAddCalled
+
+        where:
+        useTrayIcon | wasRemoveCalled | wasAddCalled
+        false | false | true
+        true | true | false
+    }
 }

--- a/src/test/groovy/com/jhegg/github/notifier/AppTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/AppTest.groovy
@@ -61,6 +61,7 @@ class AppTest extends Specification {
             println "Overridding #buildTrayIcon"
             return trayIcon
         }
+        app.metaClass.addStageListeners = {}
 
         when:
         app.addAppToTray()

--- a/src/test/groovy/com/jhegg/github/notifier/CenterLayoutControllerTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/CenterLayoutControllerTest.groovy
@@ -74,11 +74,12 @@ class CenterLayoutControllerTest extends Specification {
 
         then:
         times * gitHubService.restart()
+        centerLayoutController.textArea.getText() == text
 
         where:
-        userName || times
-        GString.EMPTY || 0
-        "josh" || 1
+        userName || times | text
+        GString.EMPTY || 0 | "Please click on Edit->Preferences and set a GitHub User Name."
+        "josh" || 1 | "Loading..."
     }
 
     @Unroll

--- a/src/test/groovy/com/jhegg/github/notifier/EditPreferencesControllerJunitTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/EditPreferencesControllerJunitTest.groovy
@@ -2,6 +2,7 @@ package com.jhegg.github.notifier
 
 import de.saxsys.javafx.test.JfxRunner
 import de.saxsys.javafx.test.TestInJfxThread
+import javafx.scene.control.CheckBox
 import javafx.scene.control.TextField
 import javafx.scene.layout.Pane
 import javafx.stage.Stage
@@ -20,12 +21,16 @@ public class EditPreferencesControllerJunitTest {
         App app = new App()
         app.token = "12345"
         app.userName = "josh"
+        app.gitHubEnterpriseHostname = "localhost"
+        app.useTrayIcon = false
 
         Pane pane = new Pane()
 
         EditPreferencesController editPreferencesController = new EditPreferencesController()
         editPreferencesController.token = new TextField()
         editPreferencesController.userName = new TextField()
+        editPreferencesController.gitHubEnterpriseHostname = new TextField()
+        editPreferencesController.systemTrayIcon = new CheckBox()
 
         app.primaryStage = new Stage()
 
@@ -33,6 +38,8 @@ public class EditPreferencesControllerJunitTest {
 
         assertEquals("12345", editPreferencesController.token.getText())
         assertEquals("josh", editPreferencesController.userName.getText())
+        assertEquals("localhost", editPreferencesController.gitHubEnterpriseHostname.getText())
+        assertFalse(editPreferencesController.systemTrayIcon.selected)
     }
 
     @Test

--- a/src/test/groovy/com/jhegg/github/notifier/EditPreferencesControllerTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/EditPreferencesControllerTest.groovy
@@ -1,6 +1,7 @@
 package com.jhegg.github.notifier
 
 import javafx.embed.swing.JFXPanel
+import javafx.scene.control.CheckBox
 import javafx.scene.control.TextField
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
@@ -16,6 +17,8 @@ class EditPreferencesControllerTest extends Specification {
     EditPreferencesController controller = new EditPreferencesController()
     TextField token = new TextField()
     TextField userName = new TextField()
+    TextField gitHubEnterpriseHostname = new TextField()
+    CheckBox systemTrayIcon = new CheckBox()
     @Shared KeyEvent enterKey = new KeyEvent(KeyEvent.KEY_PRESSED, "enter", "enter", KeyCode.ENTER, false, false, false, false)
     @Shared KeyEvent escapeKey = new KeyEvent(KeyEvent.KEY_PRESSED, "enter", "enter", KeyCode.ESCAPE, false, false, false, false)
     @Shared KeyEvent spaceKey = new KeyEvent(KeyEvent.KEY_PRESSED, "enter", "enter", KeyCode.SPACE, false, false, false, false)
@@ -28,6 +31,8 @@ class EditPreferencesControllerTest extends Specification {
         userName.setText('josh')
         controller.token = token
         controller.userName = userName
+        controller.gitHubEnterpriseHostname = gitHubEnterpriseHostname
+        controller.systemTrayIcon = systemTrayIcon
         controller.initialize()
         controller.metaClass.wasCloseDialogCalled = false
         controller.metaClass.closeDialog = { wasCloseDialogCalled = true }
@@ -45,6 +50,38 @@ class EditPreferencesControllerTest extends Specification {
         enterKey | true | true || [userName: 'josh']
         escapeKey | false | true  || [userName: '']
         spaceKey | false | false || [userName: '']
+    }
+
+    @Unroll
+    def "clicked ok with user=#testUser, token=#testToken, hostname=#testHostname, icon=#testIcon"() {
+        setup:
+        controller.app = app
+        controller.token = token
+        token.setText(testToken)
+        controller.userName = userName
+        userName.setText(testUser)
+        controller.gitHubEnterpriseHostname = gitHubEnterpriseHostname
+        gitHubEnterpriseHostname.setText(testHostname)
+        controller.systemTrayIcon = systemTrayIcon
+        systemTrayIcon.selected = testIcon
+        controller.metaClass.closeDialog = {}
+
+        when:
+        controller.clickedOk()
+
+        then:
+        app.userName == testUser
+        app.token == testToken
+        app.gitHubEnterpriseHostname == testHostname
+        // todo app.systemTrayIconEnabled == testIcon
+
+        where:
+        testUser | testToken | testHostname | testIcon
+        '' | '' | '' | false
+        'josh' | '' | '' | false
+        'josh' | '12345' | '' | false
+        'josh' | '12345' | 'localhost' | false
+        'josh' | '12345' | 'localhost' | true
     }
 
     def "setDisplayedPreferences updates fields"() {

--- a/src/test/groovy/com/jhegg/github/notifier/EditPreferencesControllerTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/EditPreferencesControllerTest.groovy
@@ -64,6 +64,9 @@ class EditPreferencesControllerTest extends Specification {
         gitHubEnterpriseHostname.setText(testHostname)
         controller.systemTrayIcon = systemTrayIcon
         systemTrayIcon.selected = testIcon
+        app.useTrayIcon = appTrayIcon
+        boolean trayIconToggled = false
+        app.metaClass.toggleTrayIcon = { trayIconToggled = true }
         controller.metaClass.closeDialog = {}
 
         when:
@@ -73,27 +76,32 @@ class EditPreferencesControllerTest extends Specification {
         app.userName == testUser
         app.token == testToken
         app.gitHubEnterpriseHostname == testHostname
-        // todo app.systemTrayIconEnabled == testIcon
+        trayIconToggled == wasTrayIconToggled
 
         where:
-        testUser | testToken | testHostname | testIcon
-        '' | '' | '' | false
-        'josh' | '' | '' | false
-        'josh' | '12345' | '' | false
-        'josh' | '12345' | 'localhost' | false
-        'josh' | '12345' | 'localhost' | true
+        testUser | testToken | testHostname | testIcon | appTrayIcon | wasTrayIconToggled
+        '' | '' | '' | false | false | false
+        'josh' | '' | '' | false | false | false
+        'josh' | '12345' | '' | false | false | false
+        'josh' | '12345' | 'localhost' | false | false | false
+        'josh' | '12345' | 'localhost' | true | false | true
+        'josh' | '12345' | 'localhost' | false | true | true
     }
 
     def "setDisplayedPreferences updates fields"() {
         setup:
         controller.token = token
         controller.userName = userName
+        controller.gitHubEnterpriseHostname = gitHubEnterpriseHostname
+        controller.systemTrayIcon = systemTrayIcon
 
         when:
-        controller.setDisplayedPreferences("12345", "someUser")
+        controller.setDisplayedPreferences("12345", "someUser", "localhost", false)
 
         then:
         token.getText() == "12345"
         userName.getText() == "someUser"
+        gitHubEnterpriseHostname.getText() == "localhost"
+        !systemTrayIcon.selected
     }
 }


### PR DESCRIPTION
This changeset will hopefully resolve issues #5, #7, and #8. It involves a refactoring of the system tray icon behavior, some modifications to window minimizing/closing behavior, and a redesign of the Edit Preferences dialog. The GitHub Enterprise hostname and whether to use the system tray icon are now configured via the Edit Preferences dialog.
