### PR TITLE
Now parsing GitHub events with more detail

### DIFF
--- a/src/main/groovy/com/jhegg/github/notifier/CenterLayoutController.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/CenterLayoutController.groovy
@@ -97,8 +97,15 @@ class CenterLayoutController {
     }
 
     void displayTextArea(GitHubEvent event) {
-        if (event != null )
-            textArea.setText(JsonOutput.prettyPrint(event.json))
+        if (event != null ) {
+            def parsedEvent = event.parse()
+            String displayedText = "Title: $parsedEvent.title\n\n" +
+                    "Message: $parsedEvent.message\n\n" +
+                    "Raw JSON: ${JsonOutput.prettyPrint(event.json)}"
+            textArea.setText(displayedText)
+        } else {
+            textArea.setText("")
+        }
     }
 
     void updateEvents(List<GitHubEvent> githubEvents) {

--- a/src/main/groovy/com/jhegg/github/notifier/DesktopNotifier.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/DesktopNotifier.groovy
@@ -1,6 +1,5 @@
 package com.jhegg.github.notifier
 
-import groovy.json.JsonSlurper
 import javafx.scene.Group
 import javafx.scene.Scene
 import javafx.stage.Stage
@@ -17,12 +16,11 @@ class DesktopNotifier {
     Stage hiddenStage
 
     void send(GitHubEvent event) {
-        def title = event.type ?: "Unknown event"
-        def message = getNotificationText(event)
+        def parsedEvent = event.parse()
         if (isPlatformLinux && hasLibNotify()) {
-            sendLibNotifyMessage(title, message)
+            sendLibNotifyMessage(parsedEvent.title, parsedEvent.message)
         } else {
-            sendJavaFxMessage(title, message)
+            sendJavaFxMessage(parsedEvent.title, parsedEvent.message)
         }
     }
 
@@ -44,18 +42,6 @@ class DesktopNotifier {
                 .text(message)
                 .hideAfter(Duration.seconds(5d))
                 .show()
-    }
-
-    String getNotificationText(GitHubEvent gitHubEvent) {
-        def json = new JsonSlurper().parseText(gitHubEvent.json)
-
-        if (gitHubEvent.type == "PushEvent") {
-            String truncatedMessage = json.payload.commits[0].message.tokenize('\n\r').get(0)
-            return "${gitHubEvent.login} pushed ${json.payload.size} commit(s) to repo ${json.repo.name}\n\n" +
-                    "\"${truncatedMessage.take(85)} ...\""
-        } else {
-            "${gitHubEvent.login} acted on repo ${json.repo.name}"
-        }
     }
 
     /**

--- a/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
@@ -33,6 +33,10 @@ class GitHubEvent implements Comparable {
                 return [title: parseCreateTitle(parsedJson), message: parseCreateMessage(parsedJson)]
             case "ForkEvent":
                 return [title: "GitHub Repo Forked", message: parseForkMessage(parsedJson)]
+            case "IssuesEvent":
+                return [title: parseIssuesTitle(parsedJson), message: parseIssuesMessage(parsedJson)]
+            case "IssueCommentEvent":
+                return [title: "GitHub Issue Comment", message: parseIssueCommentMessage(parsedJson)]
             default:
                 def loginName = parsedJson.actor.login
                 def repoName = parsedJson.repo.name
@@ -65,5 +69,21 @@ class GitHubEvent implements Comparable {
 
     private def parseForkMessage(def parsedJson) {
         return "$parsedJson.actor.login forked $parsedJson.repo.name into ${parsedJson.payload.forkee.full_name}"
+    }
+
+    private def parseIssuesTitle(def parsedJson) {
+        return "GitHub Issue ${parsedJson.payload.action.capitalize()}"
+    }
+
+    private def parseIssuesMessage(def parsedJson) {
+        String action = parsedJson.payload.action
+        switch (action) {
+            default:
+                return "$parsedJson.actor.login $action issue #$parsedJson.payload.issue.number on $parsedJson.repo.name"
+        }
+    }
+
+    private def parseIssueCommentMessage(def parsedJson) {
+        return "$parsedJson.actor.login commented on issue #$parsedJson.payload.issue.number on $parsedJson.repo.name"
     }
 }

--- a/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
@@ -37,6 +37,8 @@ class GitHubEvent implements Comparable {
                 return [title: parseIssuesTitle(parsedJson), message: parseIssuesMessage(parsedJson)]
             case "IssueCommentEvent":
                 return [title: "GitHub Issue Comment", message: parseIssueCommentMessage(parsedJson)]
+            case "WatchEvent":
+                return [title: "GitHub Repo Starred", message: parseWatchMessage(parsedJson)]
             default:
                 def loginName = parsedJson.actor.login
                 def repoName = parsedJson.repo.name
@@ -85,5 +87,9 @@ class GitHubEvent implements Comparable {
 
     private def parseIssueCommentMessage(def parsedJson) {
         return "$parsedJson.actor.login commented on issue #$parsedJson.payload.issue.number on $parsedJson.repo.name"
+    }
+
+    private def parseWatchMessage(def parsedJson) {
+        return "$parsedJson.actor.login starred $parsedJson.repo.name"
     }
 }

--- a/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
@@ -31,6 +31,8 @@ class GitHubEvent implements Comparable {
                 return [title: "GitHub Push Event", message: parsePushMessage(parsedJson)]
             case "CreateEvent":
                 return [title: parseCreateTitle(parsedJson), message: parseCreateMessage(parsedJson)]
+            case "ForkEvent":
+                return [title: "GitHub Repo Forked", message: parseForkMessage(parsedJson)]
             default:
                 def loginName = parsedJson.actor.login
                 def repoName = parsedJson.repo.name
@@ -59,5 +61,9 @@ class GitHubEvent implements Comparable {
             default:
                 return "$parsedJson.actor.login created $createdObject $ref in $parsedJson.repo.name"
         }
+    }
+
+    private def parseForkMessage(def parsedJson) {
+        return "$parsedJson.actor.login forked $parsedJson.repo.name into ${parsedJson.payload.forkee.full_name}"
     }
 }

--- a/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
@@ -27,16 +27,18 @@ class GitHubEvent implements Comparable {
     def parse() {
         def parsedJson = new JsonSlurper().parseText(json)
         switch (parsedJson.type) {
-            case "PushEvent":
-                return [title: "GitHub Push Event", message: parsePushMessage(parsedJson)]
             case "CreateEvent":
                 return [title: parseCreateTitle(parsedJson), message: parseCreateMessage(parsedJson)]
             case "ForkEvent":
                 return [title: "GitHub Repo Forked", message: parseForkMessage(parsedJson)]
+            case "GollumEvent":
+                return [title: "GitHub Wiki", message: parseGollumMessage(parsedJson)]
             case "IssuesEvent":
                 return [title: parseIssuesTitle(parsedJson), message: parseIssuesMessage(parsedJson)]
             case "IssueCommentEvent":
                 return [title: "GitHub Issue Comment", message: parseIssueCommentMessage(parsedJson)]
+            case "PushEvent":
+                return [title: "GitHub Push Event", message: parsePushMessage(parsedJson)]
             case "WatchEvent":
                 return [title: "GitHub Repo Starred", message: parseWatchMessage(parsedJson)]
             default:
@@ -79,10 +81,7 @@ class GitHubEvent implements Comparable {
 
     private def parseIssuesMessage(def parsedJson) {
         String action = parsedJson.payload.action
-        switch (action) {
-            default:
-                return "$parsedJson.actor.login $action issue #$parsedJson.payload.issue.number on $parsedJson.repo.name"
-        }
+        return "$parsedJson.actor.login $action issue #$parsedJson.payload.issue.number on $parsedJson.repo.name"
     }
 
     private def parseIssueCommentMessage(def parsedJson) {
@@ -91,5 +90,9 @@ class GitHubEvent implements Comparable {
 
     private def parseWatchMessage(def parsedJson) {
         return "$parsedJson.actor.login starred $parsedJson.repo.name"
+    }
+
+    private def parseGollumMessage(def parsedJson) {
+        return "$parsedJson.actor.login updated the wiki for repo $parsedJson.repo.name"
     }
 }

--- a/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
@@ -29,6 +29,8 @@ class GitHubEvent implements Comparable {
         switch (parsedJson.type) {
             case "CreateEvent":
                 return [title: parseCreateTitle(parsedJson), message: parseCreateMessage(parsedJson)]
+            case "DeleteEvent":
+                return [title: "GitHub Delete Event", message: parseDeleteMessage(parsedJson)]
             case "ForkEvent":
                 return [title: "GitHub Repo Forked", message: parseForkMessage(parsedJson)]
             case "GollumEvent":
@@ -37,6 +39,8 @@ class GitHubEvent implements Comparable {
                 return [title: parseIssuesTitle(parsedJson), message: parseIssuesMessage(parsedJson)]
             case "IssueCommentEvent":
                 return [title: "GitHub Issue Comment", message: parseIssueCommentMessage(parsedJson)]
+            case "PullRequestEvent":
+                return [title: "GitHub Pull Request", message: parsePullRequestMessage(parsedJson)]
             case "PushEvent":
                 return [title: "GitHub Push Event", message: parsePushMessage(parsedJson)]
             case "WatchEvent":
@@ -94,5 +98,15 @@ class GitHubEvent implements Comparable {
 
     private def parseGollumMessage(def parsedJson) {
         return "$parsedJson.actor.login updated the wiki for repo $parsedJson.repo.name"
+    }
+
+    private def parsePullRequestMessage(def parsedJson) {
+        return "$parsedJson.actor.login $parsedJson.payload.action pull request #$parsedJson.payload.number " +
+                "on repo $parsedJson.repo.name"
+    }
+
+    private def parseDeleteMessage(def parsedJson) {
+        return "$parsedJson.actor.login deleted $parsedJson.payload.ref_type $parsedJson.payload.ref " +
+                "on repo $parsedJson.repo.name"
     }
 }

--- a/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/GithubEvent.groovy
@@ -1,5 +1,6 @@
 package com.jhegg.github.notifier
 
+import groovy.json.JsonSlurper
 import groovy.transform.EqualsAndHashCode
 
 @EqualsAndHashCode
@@ -21,5 +22,42 @@ class GitHubEvent implements Comparable {
         if (this.id.equals(otherEvent.id)) { return 0 }
         if (this.id < otherEvent.id ) { return -1 }
         return 1
+    }
+
+    def parse() {
+        def parsedJson = new JsonSlurper().parseText(json)
+        switch (parsedJson.type) {
+            case "PushEvent":
+                return [title: "GitHub Push Event", message: parsePushMessage(parsedJson)]
+            case "CreateEvent":
+                return [title: parseCreateTitle(parsedJson), message: parseCreateMessage(parsedJson)]
+            default:
+                def loginName = parsedJson.actor.login
+                def repoName = parsedJson.repo.name
+                return [title: parsedJson.type, message: "$loginName acted on repo $repoName"]
+        }
+    }
+
+    private def parsePushMessage(def parsedJson) {
+        def numCommits = parsedJson.payload.size
+        def pluralCommits = numCommits == 1 ? '' : 's'
+        def ref = parsedJson.payload.ref
+        return "$parsedJson.actor.login pushed $numCommits commit$pluralCommits to $ref in $parsedJson.repo.name"
+    }
+
+    private def parseCreateTitle(def parsedJson) {
+        String createdObject = parsedJson.payload.ref_type
+        return "GitHub ${createdObject.capitalize()} Created"
+    }
+
+    private def parseCreateMessage(def parsedJson) {
+        String createdObject = parsedJson.payload.ref_type
+        def ref = parsedJson.payload.ref
+        switch (createdObject) {
+            case "repository":
+                return "$parsedJson.actor.login created $createdObject $parsedJson.repo.name"
+            default:
+                return "$parsedJson.actor.login created $createdObject $ref in $parsedJson.repo.name"
+        }
     }
 }

--- a/src/test/groovy/com/jhegg/github/notifier/CenterLayoutControllerTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/CenterLayoutControllerTest.groovy
@@ -10,6 +10,8 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static com.jhegg.github.notifier.GitHubJsonPayloadExamples.getExampleSinglePushPayload
+
 class CenterLayoutControllerTest extends Specification {
     static {
         new JFXPanel() // we need the JavaFX Toolkit to be initialized, or an IllegalStateException is thrown.
@@ -116,8 +118,12 @@ class CenterLayoutControllerTest extends Specification {
         where:
         event || result
         null || GString.EMPTY
-        new GitHubEvent(id: "123", login: "josh", created_at: "now", json: "{\"id\": \"123\"}") || "{\n    \"id\": \"123\"\n}"
+        new GitHubEvent(id: "123", login: "josh", created_at: "now", json: exampleSinglePushPayload) || pushEventExample
     }
+
+    static def pushEventExample = "Title: GitHub Push Event\n\n" +
+            "Message: SomeUser pushed 1 commit to refs/heads/master in SomeOrg/i-made-this\n\n" +
+            "Raw JSON: ${exampleSinglePushPayload}"
 
     @Unroll
     def "getNewEventsForNotification with #existing.size() oldEvents and #input.size() new, expected #output.size() result(s)"() {

--- a/src/test/groovy/com/jhegg/github/notifier/DesktopNotifierTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/DesktopNotifierTest.groovy
@@ -9,17 +9,6 @@ class DesktopNotifierTest extends Specification {
     DesktopNotifier desktopNotifier = new DesktopNotifier()
 
     @Unroll
-    def "getNotificationText for type #type and login #login"() {
-        expect:
-        desktopNotifier.getNotificationText(new GitHubEvent(type: type, login: login, json: json)) == result
-
-        where:
-        type          | login          | json                       || result
-        "PushEvent"   | "SomeUser"     | exampleSinglePushPayload   || "SomeUser pushed 1 commit(s) to repo SomeOrg/i-made-this\n\n\"I made this thing ...\""
-        "CreateEvent" | "creatorLogin" | exampleCreateRepoEventJson || "creatorLogin acted on repo SomeOrg/some-new-repo"
-    }
-
-    @Unroll
     def "send event where isPlatformLinux==#isPlatformLinux and hasLibNotify==#hasLibNotify"() {
         setup:
         boolean sentJavaFxMessage = false

--- a/src/test/groovy/com/jhegg/github/notifier/DesktopNotifierTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/DesktopNotifierTest.groovy
@@ -3,6 +3,8 @@ package com.jhegg.github.notifier
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static com.jhegg.github.notifier.GitHubJsonPayloadExamples.*
+
 class DesktopNotifierTest extends Specification {
     DesktopNotifier desktopNotifier = new DesktopNotifier()
 
@@ -12,9 +14,9 @@ class DesktopNotifierTest extends Specification {
         desktopNotifier.getNotificationText(new GitHubEvent(type: type, login: login, json: json)) == result
 
         where:
-        type          | login          | json                                               || result
-        "PushEvent"   | "SomeUser"     | GitHubJsonPayloadExamples.exampleSinglePushPayload || "SomeUser pushed 1 commit(s) to repo SomeOrg/i-made-this\n\n\"I made this thing ...\""
-        "CreateEvent" | "creatorLogin" | GitHubJsonPayloadExamples.exampleCreateEventJson   || "creatorLogin acted on repo SomeOrg/some-new-repo"
+        type          | login          | json                       || result
+        "PushEvent"   | "SomeUser"     | exampleSinglePushPayload   || "SomeUser pushed 1 commit(s) to repo SomeOrg/i-made-this\n\n\"I made this thing ...\""
+        "CreateEvent" | "creatorLogin" | exampleCreateRepoEventJson || "creatorLogin acted on repo SomeOrg/some-new-repo"
     }
 
     @Unroll
@@ -28,7 +30,7 @@ class DesktopNotifierTest extends Specification {
         desktopNotifier.isPlatformLinux = isPlatformLinux
 
         when:
-        desktopNotifier.send(new GitHubEvent(id: 1, json: GitHubJsonPayloadExamples.exampleCreateEventJson))
+        desktopNotifier.send(new GitHubEvent(id: 1, json: exampleCreateRepoEventJson))
 
         then:
         sentJavaFxMessage == wasJavaFxMessageSent

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
@@ -66,7 +66,7 @@ class GitHubEventTest extends Specification {
 
     static def forkEventExample = [
             title: "GitHub Repo Forked",
-            message: "Forkuser forked OriginalOrg/repo-name into NewOrg/repo-name",
+            message: "ForkUser forked OriginalOrg/repo-name into NewOrg/repo-name",
     ]
 
     static def unknownEventExample = [

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
@@ -46,6 +46,8 @@ class GitHubEventTest extends Specification {
         "CreateEvent" | exampleCreateRepoEventJson || createRepoEventExample
         "CreateEvent" | exampleCreateBranchEventJson || createBranchEventExample
         "ForkEvent" | exampleForkEventJson || forkEventExample
+        "IssuesEvent" | exampleIssuesEventJson || issuesEventExample
+        "IssueCommentEvent" | exampleIssueCommentEventJson || issueCommentEventExample
         "UnknownEvent" | exampleUnknownEventJson || unknownEventExample
     }
 
@@ -67,6 +69,16 @@ class GitHubEventTest extends Specification {
     static def forkEventExample = [
             title: "GitHub Repo Forked",
             message: "ForkUser forked OriginalOrg/repo-name into NewOrg/repo-name",
+    ]
+
+    static def issuesEventExample = [
+            title: "GitHub Issue Opened",
+            message: "SomeUser opened issue #1 on SomeOrg/repo-name",
+    ]
+
+    static def issueCommentEventExample = [
+            title: "GitHub Issue Comment",
+            message: "SomeUser commented on issue #1 on SomeOrg/repo-name",
     ]
 
     static def unknownEventExample = [

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
@@ -44,11 +44,13 @@ class GitHubEventTest extends Specification {
         type | json || exampleEvent
         "CreateEvent" | exampleCreateRepoEventJson || createRepoEventExample
         "CreateEvent" | exampleCreateBranchEventJson || createBranchEventExample
+        "DeleteEvent" | exampleDeleteEventJson || deleteEventExample
         "ForkEvent" | exampleForkEventJson || forkEventExample
         "GollumEvent" | exampleGollumEventJson || gollumEventExample
         "IssuesEvent" | exampleIssuesEventJson || issuesEventExample
         "IssueCommentEvent" | exampleIssueCommentEventJson || issueCommentEventExample
         "PushEvent" | exampleSinglePushPayload || pushEventExample
+        "PullRequestEvent" | examplePullRequestEventJson || pullRequestEventExample
         "WatchEvent" | exampleWatchEventJson || watchEventExample
         "UnknownEvent" | exampleUnknownEventJson || unknownEventExample
     }
@@ -91,6 +93,16 @@ class GitHubEventTest extends Specification {
     static def gollumEventExample = [
             title: "GitHub Wiki",
             message: "SomeUser updated the wiki for repo SomeOrg/repo-name",
+    ]
+
+    static def pullRequestEventExample = [
+            title: "GitHub Pull Request",
+            message: "SomeUser opened pull request #1 on repo SomeOrg/repo-name",
+    ]
+
+    static def deleteEventExample = [
+            title: "GitHub Delete Event",
+            message: "SomeUser deleted branch my-branch on repo SomeOrg/repo-name",
     ]
 
     static def unknownEventExample = [

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
@@ -48,6 +48,7 @@ class GitHubEventTest extends Specification {
         "ForkEvent" | exampleForkEventJson || forkEventExample
         "IssuesEvent" | exampleIssuesEventJson || issuesEventExample
         "IssueCommentEvent" | exampleIssueCommentEventJson || issueCommentEventExample
+        "WatchEvent" | exampleWatchEventJson || watchEventExample
         "UnknownEvent" | exampleUnknownEventJson || unknownEventExample
     }
 
@@ -79,6 +80,11 @@ class GitHubEventTest extends Specification {
     static def issueCommentEventExample = [
             title: "GitHub Issue Comment",
             message: "SomeUser commented on issue #1 on SomeOrg/repo-name",
+    ]
+
+    static def watchEventExample = [
+            title: "GitHub Repo Starred",
+            message: "SomeUser starred SomeOrg/repo-name",
     ]
 
     static def unknownEventExample = [

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
@@ -2,6 +2,9 @@ package com.jhegg.github.notifier
 
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
+
+import static com.jhegg.github.notifier.GitHubJsonPayloadExamples.*
 
 class GitHubEventTest extends Specification {
     @Shared def event = new GitHubEvent(id: 1)
@@ -28,4 +31,46 @@ class GitHubEventTest extends Specification {
         event != eventTwo
         eventTwo != event
     }
+
+    @Unroll
+    def "title and message for type: #type"() {
+        given:
+        GitHubEvent theEvent = new GitHubEvent(type: type, login: "login", created_at: "now", json: json)
+
+        expect:
+        theEvent.parse() == [title: exampleEvent.title, message: exampleEvent.message]
+
+        where:
+        type | json || exampleEvent
+        "PushEvent" | exampleSinglePushPayload || pushEventExample
+        "CreateEvent" | exampleCreateRepoEventJson || createRepoEventExample
+        "CreateEvent" | exampleCreateBranchEventJson || createBranchEventExample
+        "ForkEvent" | exampleForkEventJson || forkEventExample
+        "UnknownEvent" | exampleUnknownEventJson || unknownEventExample
+    }
+
+    static def pushEventExample = [
+            title: "GitHub Push Event",
+            message: "SomeUser pushed 1 commit to refs/heads/master in SomeOrg/i-made-this",
+    ]
+
+    static def createRepoEventExample = [
+            title: "GitHub Repository Created",
+            message: "CreatorUser created repository SomeOrg/some-new-repo",
+    ]
+
+    static def createBranchEventExample = [
+            title: "GitHub Branch Created",
+            message: "CreatorUser created branch toggle-system-tray-icon in SomeOrg/some-existing-repo",
+    ]
+
+    static def forkEventExample = [
+            title: "GitHub Repo Forked",
+            message: "Forkuser forked OriginalOrg/repo-name into NewOrg/repo-name",
+    ]
+
+    static def unknownEventExample = [
+            title: "UnknownEvent",
+            message: "username acted on repo username/reponame",
+    ]
 }

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubEventTest.groovy
@@ -42,12 +42,13 @@ class GitHubEventTest extends Specification {
 
         where:
         type | json || exampleEvent
-        "PushEvent" | exampleSinglePushPayload || pushEventExample
         "CreateEvent" | exampleCreateRepoEventJson || createRepoEventExample
         "CreateEvent" | exampleCreateBranchEventJson || createBranchEventExample
         "ForkEvent" | exampleForkEventJson || forkEventExample
+        "GollumEvent" | exampleGollumEventJson || gollumEventExample
         "IssuesEvent" | exampleIssuesEventJson || issuesEventExample
         "IssueCommentEvent" | exampleIssueCommentEventJson || issueCommentEventExample
+        "PushEvent" | exampleSinglePushPayload || pushEventExample
         "WatchEvent" | exampleWatchEventJson || watchEventExample
         "UnknownEvent" | exampleUnknownEventJson || unknownEventExample
     }
@@ -85,6 +86,11 @@ class GitHubEventTest extends Specification {
     static def watchEventExample = [
             title: "GitHub Repo Starred",
             message: "SomeUser starred SomeOrg/repo-name",
+    ]
+
+    static def gollumEventExample = [
+            title: "GitHub Wiki",
+            message: "SomeUser updated the wiki for repo SomeOrg/repo-name",
     ]
 
     static def unknownEventExample = [

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
@@ -48,16 +48,77 @@ class GitHubJsonPayloadExamples {
     "type": "PushEvent"
 }"""
 
-    static String exampleCreateEventJson = """{
+    static String exampleCreateRepoEventJson = """{
     "id": "2671420223",
     "actor": {
         "login": "CreatorUser",
         "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "description": "",
+        "master_branch": "master",
+        "pusher_type": "user",
+        "ref": null,
+        "ref_type": "repository"
     },
     "created_at": "2015-02-02T01:15:07Z",
     "repo": {
         "name": "SomeOrg/some-new-repo",
     },
     "type": "CreateEvent"
+}"""
+
+    static String exampleCreateBranchEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "CreatorUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "description": "",
+        "master_branch": "master",
+        "pusher_type": "user",
+        "ref": "toggle-system-tray-icon",
+        "ref_type": "branch"
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "SomeOrg/some-existing-repo",
+    },
+    "type": "CreateEvent"
+}"""
+
+    static String exampleForkEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "ForkUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "forkee": {
+            "full_name": "NewOrg/repo-name",
+        },
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "public": true,
+    "repo": {
+        "name": "OriginalOrg/repo-name",
+    },
+    "type": "ForkEvent"
+}"""
+
+    static String exampleUnknownEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "username",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "username/reponame",
+    },
+    "type": "UnknownEvent"
 }"""
 }

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
@@ -107,6 +107,53 @@ class GitHubJsonPayloadExamples {
     "type": "ForkEvent"
 }"""
 
+    static String exampleIssuesEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "SomeUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "action": "opened",
+        "issue": {
+            "assignee": null,
+            "body": "The reason this is an issue is because x, y, and z.",
+            "number": 1,
+            "title": "This is an issue",
+        }
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "SomeOrg/repo-name",
+    },
+    "type": "IssuesEvent"
+}"""
+
+    static String exampleIssueCommentEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "SomeUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "action": "created",
+        "issue": {
+            "assignee": null,
+            "body": "The reason this is an issue is because x, y, and z.",
+            "number": 1,
+            "title": "This is an issue",
+        },
+        "comment": {
+            "body": "This is my comment",
+        },
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "SomeOrg/repo-name",
+    },
+    "type": "IssueCommentEvent"
+}"""
+
     static String exampleUnknownEventJson = """{
     "id": "2671420223",
     "actor": {

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
@@ -170,6 +170,28 @@ class GitHubJsonPayloadExamples {
     "type": "WatchEvent"
 }"""
 
+    static String exampleGollumEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "SomeUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "pages": [
+            {
+                "page_name": "Home",
+                "title": "Home",
+                "action": "edited",
+            }
+        ],
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "SomeOrg/repo-name",
+    },
+    "type": "GollumEvent"
+}"""
+
     static String exampleUnknownEventJson = """{
     "id": "2671420223",
     "actor": {

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
@@ -192,6 +192,42 @@ class GitHubJsonPayloadExamples {
     "type": "GollumEvent"
 }"""
 
+    static String examplePullRequestEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "SomeUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "action": "opened",
+        "number": 1,
+        "pull_request": {
+        },
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "SomeOrg/repo-name",
+    },
+    "type": "PullRequestEvent"
+}"""
+
+    static String exampleDeleteEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "SomeUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "ref_type": "branch",
+        "ref": "my-branch",
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "SomeOrg/repo-name",
+    },
+    "type": "DeleteEvent"
+}"""
+
     static String exampleUnknownEventJson = """{
     "id": "2671420223",
     "actor": {

--- a/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
+++ b/src/test/groovy/com/jhegg/github/notifier/GitHubJsonPayloadExamples.groovy
@@ -154,6 +154,22 @@ class GitHubJsonPayloadExamples {
     "type": "IssueCommentEvent"
 }"""
 
+    static String exampleWatchEventJson = """{
+    "id": "2671420223",
+    "actor": {
+        "login": "SomeUser",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?",
+    },
+    "payload": {
+        "action": "started",
+    },
+    "created_at": "2015-02-02T01:15:07Z",
+    "repo": {
+        "name": "SomeOrg/repo-name",
+    },
+    "type": "WatchEvent"
+}"""
+
     static String exampleUnknownEventJson = """{
     "id": "2671420223",
     "actor": {


### PR DESCRIPTION
This does not yet parse all possible GitHub events, but the placeholder text should be good enough for now. The major changes are that:
- Notifications have a better title and more specific message for most events.
- The main window details pane includes the title and message, in addition to the raw json. I don't yet have a good plan for displaying the raw json (maybe that's not important?).

This will hopefully resolve issues #2 and #10 .
