### PR TITLE
Resolve deadlock on OS X when disabling tray icon

### DIFF
--- a/src/main/groovy/com/jhegg/github/notifier/App.groovy
+++ b/src/main/groovy/com/jhegg/github/notifier/App.groovy
@@ -205,9 +205,8 @@ class App extends Application {
     void removeAppFromTray() {
         if (trayIcon) {
             primaryStage.iconifiedProperty().removeListener(minimizeWindowChangeListener)
-            Platform.runLater {
-                SystemTray tray = getSystemTray()
-                tray.remove(trayIcon)
+            EventQueue.invokeLater {
+                getSystemTray().remove(trayIcon)
                 trayIcon = null
             }
         }


### PR DESCRIPTION
This resolves issue #16, where disabling the tray icon caused a deadlock on OS X. The problem was that I used the JavaFX thread to interact with AWT, when I needed to use the AWT EventQueue.
